### PR TITLE
Add configurable RPC request delay

### DIFF
--- a/config-sample.toml
+++ b/config-sample.toml
@@ -59,6 +59,7 @@ etherscan_api_key = "some_api_key" # Demeter-fetch have to query start/end block
 force_no_proxy = false # if force_no_proxy==true, will query ethereum rpc without proxy.
 # height_cache_path = "" # path of height cache file, if leave to none, height cache will be saved in to path
 thread=5
+#delay=0 # wait this many seconds between rpc requests
 
 [from.chifra]
 etherscan_api_key = "" # Api key of etherscan, If this is set, query from etherscan will be faster.

--- a/config-samples/basic_rpc.toml
+++ b/config-samples/basic_rpc.toml
@@ -16,6 +16,8 @@ is_token0_base = false
 [from.rpc] # If you want to download from rpc interface, use this section
 end_point = "https://192.168.0.100:8545"
 etherscan_api_key = "some_api_key" # Api key of etherscan
+# wait this many seconds between rpc requests
+delay = 0
 
 [to]
 type = "tick" # minute or tick or raw

--- a/config-samples/rpc_selfhost_node.toml
+++ b/config-samples/rpc_selfhost_node.toml
@@ -21,6 +21,7 @@ batch_size = 2000
 etherscan_api_key = "Your key at XXXScan"
 # More thread if your node is fast enough
 thread = 10
+#delay = 0
 
 
 [to]

--- a/config-samples/rpc_thread.toml
+++ b/config-samples/rpc_thread.toml
@@ -14,6 +14,7 @@ etherscan_api_key = "Your key at XXXScan"
 # If you use public node service like alchemy or infura, be sure set thread lower,
 # Too frequency requests will get you banned by those service.
 thread = 2
+#delay = 0
 
 
 [to]

--- a/config-samples/rpc_unstable_connection.toml
+++ b/config-samples/rpc_unstable_connection.toml
@@ -15,6 +15,7 @@ etherscan_api_key = "Your key at XXXScan"
 # If you can not reach etherscan but have a selfhost node, you can set force_no_proxy = true
 # this will request etherscan with proxy, but no proxy when request your node.
 force_no_proxy = true
+#delay = 0
 
 [to]
 type = "minute" # minute or tick or raw

--- a/demeter_fetch/common/_typing.py
+++ b/demeter_fetch/common/_typing.py
@@ -122,6 +122,7 @@ class RpcConfig:
     force_no_proxy: bool = False  # if set to true, will ignore proxy setting
     height_cache_path: str = None
     thread: int = 10
+    delay: float = 0  # seconds to wait between rpc requests
 
 
 @dataclass

--- a/demeter_fetch/core/config.py
+++ b/demeter_fetch/core/config.py
@@ -124,6 +124,7 @@ def convert_to_config(conf_file: dict) -> Config:
             force_no_proxy = get_item_with_default_3(conf_file, "from", "rpc", "force_no_proxy", False)
             height_cache_path = get_item_with_default_3(conf_file, "from", "rpc", "height_cache_path", None)
             thread = get_item_with_default_3(conf_file, "from", "rpc", "thread", None)
+            delay = get_item_with_default_3(conf_file, "from", "rpc", "delay", 0)
 
             from_config.rpc = RpcConfig(
                 end_point=end_point,
@@ -134,6 +135,7 @@ def convert_to_config(conf_file: dict) -> Config:
                 force_no_proxy=force_no_proxy,
                 height_cache_path=height_cache_path,
                 thread=thread,
+                delay=delay,
             )
         case DataSource.big_query:
             if "big_query" not in conf_file["from"]:

--- a/demeter_fetch/sources/rpc.py
+++ b/demeter_fetch/sources/rpc.py
@@ -65,8 +65,9 @@ def query_logs(
     skip_timestamp: bool = False,
     height_cache_path: str = None,
     thread: int = 10,
+    delay: float = 0,
 ) -> pd.DataFrame:
-    client = rpc_utils.EthRpcClient(end_point, http_proxy, auth_string)
+    client = rpc_utils.EthRpcClient(end_point, http_proxy, auth_string, delay)
     utils.print_log(f"Will download from height {start_height} to {end_height}")
     try:
         tmp_files_paths: List[str] = rpc_utils.query_event_by_height_concurrent(
@@ -141,6 +142,7 @@ def rpc_pool(config: FromConfig, save_path: str, day: date) -> pd.DataFrame:
         skip_timestamp=False,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     return daily_df
@@ -170,6 +172,7 @@ def rpc_uni_v4_pool(config: FromConfig, save_path: str, day: date) -> pd.DataFra
         skip_timestamp=False,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     return daily_df
@@ -199,6 +202,7 @@ def rpc_proxy_lp(config: FromConfig, save_path: str, day: date) -> pd.DataFrame:
         skip_timestamp=False,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     return daily_df
@@ -224,6 +228,7 @@ def rpc_proxy_transfer(config: FromConfig, save_path: str, day: date) -> pd.Data
         skip_timestamp=True,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     return daily_df
@@ -231,7 +236,9 @@ def rpc_proxy_transfer(config: FromConfig, save_path: str, day: date) -> pd.Data
 
 def rpc_uni_tx(config: FromConfig, tx_hashes: pd.Series) -> pd.DataFrame:
     http_proxy = config.http_proxy if not config.rpc.force_no_proxy else None
-    client = rpc_utils.EthRpcClient(config.rpc.end_point, http_proxy, config.rpc.auth_string)
+    client = rpc_utils.EthRpcClient(
+        config.rpc.end_point, http_proxy, config.rpc.auth_string, config.rpc.delay
+    )
     df = rpc_utils.query_tx(client, tx_hashes)
     # df = df.drop(columns=["from", "to"])
     return df
@@ -264,6 +271,7 @@ def rpc_aave(config: FromConfig, save_path: str, day: date, tokens):
         skip_timestamp=False,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     daily_df["topics"] = daily_df["topics"].apply(lambda x: split_topic(x))
@@ -294,6 +302,7 @@ def rpc_squeeth(config: FromConfig, save_path: str, day: date) -> pd.DataFrame:
         skip_timestamp=True,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     daily_df["block_timestamp"] = daily_df["data"].apply(
@@ -320,6 +329,7 @@ def rpc_gmx_v2(config: FromConfig, save_path: str, day: date):
         skip_timestamp=True,
         height_cache_path=config.rpc.height_cache_path,
         thread=config.rpc.thread,
+        delay=config.rpc.delay,
     )
     daily_df = _update_df(daily_df)
     return daily_df

--- a/demeter_fetch/sources/rpc_utils.py
+++ b/demeter_fetch/sources/rpc_utils.py
@@ -1,6 +1,7 @@
 import os.path
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
 
 import numpy as np
 import pandas as pd
@@ -28,7 +29,7 @@ class GetLogsParam:
 
 
 class EthRpcClient:
-    def __init__(self, endpoint: str, proxy="", auth=""):
+    def __init__(self, endpoint: str, proxy="", auth="", delay: float = 0):
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(pool_connections=5, pool_maxsize=20)
         self.session.mount("https://", adapter)
@@ -45,6 +46,7 @@ class EthRpcClient:
             if proxy
             else {}
         )
+        self.delay = delay
 
     def __del__(self):
         self.session.close()
@@ -66,7 +68,12 @@ class EthRpcClient:
         return content["result"]
 
     def do_post(self, param):
-        return self.session.post(self.endpoint, json=param, proxies=self.proxies, headers=self.headers)
+        response = self.session.post(
+            self.endpoint, json=param, proxies=self.proxies, headers=self.headers
+        )
+        if self.delay > 0:
+            time.sleep(self.delay)
+        return response
 
     def get_block(self, height):
         return self.send("eth_getBlockByNumber", [hex(height), False])

--- a/docs/release_note.md
+++ b/docs/release_note.md
@@ -1,3 +1,7 @@
+# v1.3.5
+
+* add `delay` option in rpc config to control time between requests
+
 # v1.3.4
 
 * [Breaking change] Rename realizedNetYield in GMX V2 minute file to realizedProfit

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -38,7 +38,7 @@ class UniLpDataTest(unittest.TestCase):
                 )
             ]
         )
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         height_cache = rpc.HeightCacheManager(typing.ChainType.polygon, self.config["to_path"])
         files = rpc.query_event_by_height_concurrent(
             chain=typing.ChainType.polygon,
@@ -70,7 +70,7 @@ class UniLpDataTest(unittest.TestCase):
                 )
             ]
         )
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         height_cache = rpc.HeightCacheManager(typing.ChainType.polygon, self.config["to_path"])
         files = rpc.query_event_by_height(
             chain=typing.ChainType.polygon,
@@ -103,7 +103,7 @@ class UniLpDataTest(unittest.TestCase):
             ]
         )
 
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         files = self.query_3_save_2(client)
         print(files)
         self.assertTrue(len(files) == 2)
@@ -116,7 +116,7 @@ class UniLpDataTest(unittest.TestCase):
             ]
         )
 
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         files = self.query_3_save_2(client)
         print(files)
         self.assertTrue(len(files) == 2)
@@ -147,7 +147,7 @@ class UniLpDataTest(unittest.TestCase):
         )
 
     def test_query_event_by_height_save_rest_remove_last(self):
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         files = self.query_3_save_2(client)
         # just remove the last file.
         self.remove_tmp_file(["polygon-0x45dda9cb7c25131df268515131f647d726f50608-42448301-42448799.tmp.pkl"])
@@ -156,7 +156,7 @@ class UniLpDataTest(unittest.TestCase):
         self.assertTrue(len(files) == 2)
 
     def test_query_event_by_height_save_rest_remove_first(self):
-        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890")
+        client = rpc.EthRpcClient(self.config["end_point"], "127.0.0.1:7890", delay=0)
         files = self.query_3_save_2(client)
         # just remove the first file.
         self.remove_tmp_file(["polygon-0x45dda9cb7c25131df268515131f647d726f50608-42447301-42448300.tmp.pkl"])
@@ -166,7 +166,7 @@ class UniLpDataTest(unittest.TestCase):
 
     def test_query_tx_receipt(self):
         df = rpc.query_event_by_tx(
-            rpc.EthRpcClient(self.config["end_point"]),
+            rpc.EthRpcClient(self.config["end_point"], delay=0),
             pd.Series(
                 [
                     "0xb4caa7d62ece248f8261d5e63ee76e69ed9fef0c9c72ea6cd33eae0ef9726512",
@@ -196,7 +196,7 @@ class UniLpDataTest(unittest.TestCase):
 
     def test_query_tx(self):
         df = rpc.query_tx(
-            rpc.EthRpcClient(self.config["end_point"]),
+            rpc.EthRpcClient(self.config["end_point"], delay=0),
             pd.Series(
                 [
                     "0xb4caa7d62ece248f8261d5e63ee76e69ed9fef0c9c72ea6cd33eae0ef9726512",


### PR DESCRIPTION
## Summary
- allow configuring delay between RPC requests
- wire new field through config handling
- document new option in sample configs
- document new option in release notes
- update tests for updated constructor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684b243b98308326860fe3b1a21bd6de