### PR TITLE
Add eth_abi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "db-dtypes>=1.2.0",
         "argparse>=1.4.0",
         "sqlitedict>=2.1.0",
+        "eth_abi>=5.2.0",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary
- ensure `eth_abi>=5.2.0` is installed with the package

## Testing
- `pip install -e .`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'config.toml')*

------
https://chatgpt.com/codex/tasks/task_e_684b37b5b85483268021f1a0a1d50f78